### PR TITLE
Fix 'cfgov-deployed' queries to not use 'SINCE this quarter'

### DIFF
--- a/src/newrelic.coffee
+++ b/src/newrelic.coffee
@@ -264,7 +264,7 @@ plugin = (robot) ->
     targetsQuery = """
       SELECT uniques(target)
       FROM CFGovDeploy
-      SINCE this quarter
+      SINCE 120 days ago
       FACET environment
       LIMIT 1000
     """
@@ -277,7 +277,7 @@ plugin = (robot) ->
         )
         query = _.template("""
           SELECT * FROM CFGovDeploy
-          SINCE this quarter
+          SINCE 120 days ago
           WHERE target = '${ target }'
           LIMIT 1
         """)


### PR DESCRIPTION
This corrects a misunderstanding of how `SINCE this quarter` works in NRQL. I wrongly assumed it would be comparable to `SINCE 90 days ago`, but it's really since the beginning of the current quarter, which makes sense. But it's not what we want. We just want to go back sufficiently far enough, which is what this change gets us.