### PR TITLE
Simplify Alert subscriptions

### DIFF
--- a/src/newrelic.coffee
+++ b/src/newrelic.coffee
@@ -27,7 +27,7 @@
 #   hubot newrelic users emails - Returns a list of all user emails
 #   hubot newrelic alerts - Returns a list of active alert violations matching the current channel's subscriptions
 #   hubot newrelic alerts all - Returns a list of all active alerts
-#   hubot newrelic alerts subscribe <pattern> subscribe the current channel to alerts whose policy name(s) matches <pattern>. Regexes are OK, eg cf.gov*
+#   hubot newrelic alerts subscribe <pattern> subscribe the current channel to alerts whose policy name(s) matches <pattern>. Simple matching patterns such as '*' will work, eg cf.gov*
 #   hubot newrelic alerts unsubscribe <subscription_id> remove an existing subscription
 #   hubot newrelic alerts subscriptions - show the current channel's subscriptions
 #   hubot newrelic alerts set <setting> - enable an optional alert setting, like "verbose"


### PR DESCRIPTION
Removes support for subscribing to alerts on fields other than policy name. With this commit, all alert subscriptions will be for the Alert policy name.

Subscribes to alerts in a case-insensitive manner.

Example usage supported after this commit:

`bot newrelic alerts subscribe Public Data Platform*`

`bot newrelic alerts subscribe cf.gov-*`

Spaces will work fine; case will not matter.